### PR TITLE
sheet naming issue temp fix

### DIFF
--- a/source/read/readXlsx.js
+++ b/source/read/readXlsx.js
@@ -84,7 +84,7 @@ export default function readXlsx(contents, xml, options = {}) {
 
   // Parse sheet data.
   const sheet = parseSheet(
-    contents[`xl/${fileNames.sheets[sheetRelationId]}`],
+    contents[`xl/${fileNames.sheets[sheetRelationId]}`] || contents[(fileNames.sheets[sheetRelationId] || '/').substring(1)],
     xml,
     values,
     styles,


### PR DESCRIPTION
I found an excel file where `fileNames.sheets[sheetRelationId] = /xl/worksheets/sheet1.xml` 
![image](https://user-images.githubusercontent.com/19733021/125212090-c6b5b380-e2ca-11eb-9a27-9c5962c60089.png)

Content file
![image](https://user-images.githubusercontent.com/19733021/125212112-e77e0900-e2ca-11eb-899b-2986d443b844.png)
