### PR TITLE
Re-export Error type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ import {
 export {
 	Schema,
 	ParsedObjectsResult,
+	Error,
 	Row,
 	Integer,
 	Email,


### PR DESCRIPTION
The Error type is useful when doing something like:
```
const [errors, setErrors] = useState<Error[]>();
```
While it can be imported from `read-excel-file/types`, re-exporting it makes things tiny little bit easier.