### PR TITLE
Replace unzipper dependency with fflate for Node.js stream unzip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.9",
-        "fflate": "^0.8.2",
-        "unzipper": "^0.12.3"
+        "fflate": "^0.8.2"
       },
       "devDependencies": {
         "@babel/cli": "^7.17.10",
@@ -2067,12 +2066,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "license": "MIT"
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2358,12 +2351,6 @@
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "license": "MIT"
-    },
     "node_modules/cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -2475,15 +2462,6 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-2.0.0.tgz",
       "integrity": "sha512-Y+zZAmv7p2zOdpyZcSIA+aIxohsyfTcNaMeh3YJn9exq85bQhso65Wz9IhjYYNB4zyvXnfi7Ae+FuygARljVJw==",
       "dev": true
-    },
-    "node_modules/duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "readable-stream": "^2.0.2"
-      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.541",
@@ -2689,20 +2667,6 @@
         "is-callable": "^1.1.3"
       }
     },
-    "node_modules/fs-extra": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -2892,7 +2856,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
     },
     "node_modules/has": {
       "version": "1.0.4",
@@ -3001,7 +2966,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/internal-slot": {
       "version": "1.0.5",
@@ -3419,18 +3385,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -3808,12 +3762,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node_modules/node-int64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "license": "MIT"
-    },
     "node_modules/node-releases": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
@@ -4165,12 +4113,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -4193,33 +4135,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readable-stream/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -4663,21 +4578,6 @@
       "integrity": "sha512-lpT8hSQp9jAKp9mhtBU4Xjon8LPGBvLIuBiSVhMEtmLecTh2mO0tlqrAMp47tBXzMr13NJMQ2lf7RpQGLJ3HsQ==",
       "dev": true
     },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -4985,28 +4885,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/unzipper": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
-      "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
-      "license": "MIT",
-      "dependencies": {
-        "bluebird": "~3.7.2",
-        "duplexer2": "~0.1.4",
-        "fs-extra": "^11.2.0",
-        "graceful-fs": "^4.2.2",
-        "node-int64": "^0.4.0"
-      }
-    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
@@ -5036,12 +4914,6 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
   },
   "dependencies": {
     "@xmldom/xmldom": "^0.9.9",
-    "fflate": "^0.8.2",
-    "unzipper": "^0.12.3"
+    "fflate": "^0.8.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.10",

--- a/source/zip/unzipFromStream.js
+++ b/source/zip/unzipFromStream.js
@@ -1,22 +1,15 @@
 import { Buffer } from 'buffer'
 
-// `unzipper` has a bug when it doesn't include "@aws-sdk/client-s3" package in the `dependencies`
-// which causes some "bundlers" throw an error.
-// https://github.com/ZJONSSON/node-unzipper/issues/330
+// `fflate`'s `Unzip` is a forward-streaming unzipper: it reads a `.zip` archive
+// from its local file headers as bytes arrive, so a Node.js stream is never
+// buffered into memory in full. `UnzipInflate` is its `DEFLATE` decompressor.
 //
-// One workaround is to install "@aws-sdk/client-s3" package manually, which would still lead to increased bundle size.
-// If the code is bundled for server-side-use only, that is will not be used in a web browser,
-// then the increased bundle size would not be an issue.
-//
-// Another workaround could be to "alias" "@aws-sdk/client-s3" package in a "bundler" configuration file
-// with a path to a `*.js` file containing just "export default null". But that kind of a workaround would also
-// result in errors when using other packages that `import` anything from "@aws-sdk/client-s3" package,
-// so it's not really a workaround but more of a ticking bomb.
-//
-import unzip from 'unzipper'
-
-// Althernatively, it could use `fflate` if someone writes an example of handling a Node.js stream.
+// `Unzip` doesn't speak the Node.js stream interface, though — it has its own
+// `push(chunk)` / `onfile` / `entry.ondata` protocol — so this function does the
+// plumbing manually: it forwards each chunk from the Node.js stream into
+// `unzip.push()` and collects the decompressed entries.
 // https://github.com/101arrowz/fflate/issues/251
+import { Unzip, UnzipInflate } from 'fflate'
 
 /**
  * Reads `*.zip` file contents.
@@ -28,8 +21,6 @@ export default function unzipFromStream(stream, { filter } = {}) {
 	const files = {}
 
 	return new Promise((resolve, reject) => {
-		const promises = []
-
 		let errored = false
 
 		const onError = (error) => {
@@ -39,86 +30,101 @@ export default function unzipFromStream(stream, { filter } = {}) {
 			}
 		}
 
-		stream
-			// This first "error" listener catches the original stream errors.
-			//
-			// That's because the .pipe() method does not automatically propagate errors
-			// from a source (input) stream to the destination stream or the end of the pipeline.
-			// You would need to attach an 'error' event handler to each stream in the chain.
-			//
-			// A more convenient alternative would be to use `stream.pipeline()` function:
-			// `pipeline(stream1, stream2, (error) => { ... })`
-			//
-			.on('error', onError)
-			// Pipe the input stream through the unzipper stream.
-			.pipe(unzip.Parse())
-			// This second "error" listener catches the unzipper stream errors.
-			//
-			// That's because the .pipe() method does not automatically propagate errors
-			// from a source (input) stream to the destination stream or the end of the pipeline.
-			// You would need to attach an 'error' event handler to each stream in the chain.
-			//
-			// A more convenient alternative would be to use `stream.pipeline()` function:
-			// `pipeline(stream1, stream2, (error) => { ... })`
-			//
-			.on('error', onError)
-			// The unzipper stream is closed when all `entries` have been reported.
-			.on('finish', () => {
-				if (!errored) {
-					// Wait for all `entries` to be read.
-					// The second argument of `.then()` function is not required
-					// but I didn't remove it just to potentially prevent any potential silly bugs
-					// in case of some potential changes in some potential future.
-					Promise.all(promises).then(() => {
-						resolve(files)
-					}, onError)
+		// Every `.zip` archive (and therefore every `.xlsx` file) starts with the
+		// "PK" magic bytes of a local file header or an end-of-central-directory
+		// record. `fflate`'s `Unzip` silently yields zero entries for data that
+		// contains no archive headers at all, so validate the magic bytes up front
+		// to reject non-zip input with a clear error rather than an empty result.
+		const magicBytes = []
+		let magicChecked = false
+		const checkZipMagicBytes = (chunk) => {
+			for (let i = 0; i < chunk.length && magicBytes.length < 2; i++) {
+				magicBytes.push(chunk[i])
+			}
+			if (magicBytes.length === 2) {
+				magicChecked = true
+				if (magicBytes[0] !== 0x50 || magicBytes[1] !== 0x4B) {
+					onError(new Error('Invalid zip data: not a zip archive'))
 				}
-			})
-			.on('entry', (entry) => {
-				// See if this file should be ignored.
-				let ignore = false
-				// `entry.type` could be 'Directory' or 'File'.
-				// Ignore anything except files.
-				if (entry.type === 'Directory') {
-					ignore = true
-				}
-				if (errored) {
-					ignore = true
-				}
-				if (filter) {
-					if (!filter({ path: entry.path })) {
-						ignore = true
-					}
-				}
+			}
+		}
 
-				// If this file should be ignored.
-				if (ignore) {
-					// Call `entry.autodrain()` when you do not intend to process a specific `entry`'s raw data.
-					// Otherwise, if an `entry` is not consumed (via .pipe(), .buffer(), or .autodrain()),
-					// the stream will halt, preventing further file processing.
-					entry.autodrain().on('error', onError)
+		// `Unzip` discovers each archive entry from its local file header as the
+		// archive bytes are pushed in, calling `onfile` for every entry.
+		const unzip = new Unzip((entry) => {
+			if (errored) {
+				return
+			}
+
+			// Skip directory entries (their names end with a slash). Only files
+			// are reported, matching the `Record<path, contents>` return type.
+			if (entry.name.endsWith('/')) {
+				return
+			}
+
+			// See if this file should be ignored.
+			// Not calling `entry.start()` means the entry is skipped entirely:
+			// its data is never decompressed (or even buffered for long).
+			if (filter && !filter({ path: entry.name })) {
+				return
+			}
+
+			const chunks = []
+
+			// `entry.ondata` is called with each decompressed chunk of the entry,
+			// and a final time with `isLast === true` once the entry is complete.
+			entry.ondata = (error, chunk, isLast) => {
+				if (error) {
+					return onError(error)
+				}
+				chunks.push(chunk)
+				if (isLast) {
+					files[entry.name] = Buffer.concat(chunks)
+				}
+			}
+
+			// Start decompressing this entry.
+			entry.start()
+		})
+
+		// Register the `DEFLATE` decompressor (compression method `8`), which is
+		// what `.xlsx` archives use. The "stored" method (`0`, no compression) is
+		// handled by `fflate` out of the box, so it doesn't need to be registered.
+		unzip.register(UnzipInflate)
+
+		stream
+			// Catch errors from the source stream (e.g. a file read error).
+			.on('error', onError)
+			.on('data', (chunk) => {
+				if (errored) {
 					return
 				}
-
-				const chunks = []
-
-				promises.push(new Promise((resolve) => {
-					// `entry` seems to be a generic Node.js stream.
-					// `entry.pipe()` pipes the file contents to a stream.
-					// `entry.stream()` returns a readable stream.
-					// `entry.buffer()` returns a promise that resolves to a `Buffer` with the file contents.
-					entry
-						.on('data', (data) => {
-							chunks.push(data)
-						})
-						.on('error', (error) => {
-							onError(error)
-						})
-						.on('finish', () => {
-							files[entry.path] = Buffer.concat(chunks)
-							resolve()
-						})
-				}))
+				if (!magicChecked) {
+					checkZipMagicBytes(chunk)
+					if (errored) {
+						return
+					}
+				}
+				try {
+					// Push the next archive chunk. `UnzipInflate` is synchronous,
+					// so any entries completed by this chunk have already populated
+					// `files` by the time `push()` returns.
+					unzip.push(chunk, false)
+				} catch (error) {
+					onError(error)
+				}
+			})
+			.on('end', () => {
+				if (errored) {
+					return
+				}
+				try {
+					// Signal the end of the archive and flush any remaining state.
+					unzip.push(new Uint8Array(0), true)
+					resolve(files)
+				} catch (error) {
+					onError(error)
+				}
 			})
 	})
 }

--- a/source/zip/unzipFromStream.test.js
+++ b/source/zip/unzipFromStream.test.js
@@ -1,0 +1,116 @@
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+
+import { Readable } from 'stream'
+import { zipSync, strToU8, strFromU8 } from 'fflate'
+
+import unzipFromStream from './unzipFromStream.js'
+
+// Builds a `.zip` archive in memory.
+// `level: 0` produces "stored" (uncompressed) entries; the default produces `DEFLATE` ones.
+function createZip(entries, { level } = {}) {
+	const archive = {}
+	for (const name of Object.keys(entries)) {
+		archive[name] = level === undefined
+			? strToU8(entries[name])
+			: [strToU8(entries[name]), { level }]
+	}
+	return Buffer.from(zipSync(archive))
+}
+
+// Emits `buffer` through a Node.js readable stream, split into `chunkSize`-byte chunks
+// (to exercise reading across arbitrary chunk boundaries).
+function streamFrom(buffer, { chunkSize = buffer.length } = {}) {
+	const chunks = []
+	for (let i = 0; i < buffer.length; i += chunkSize) {
+		chunks.push(buffer.subarray(i, i + chunkSize))
+	}
+	return Readable.from(chunks.length > 0 ? chunks : [Buffer.alloc(0)])
+}
+
+// Reads the resulting entries back as strings for easy comparison.
+function asStrings(files) {
+	const result = {}
+	for (const path of Object.keys(files)) {
+		result[path] = strFromU8(files[path])
+	}
+	return result
+}
+
+describe('unzipFromStream', () => {
+	it('should read DEFLATE-compressed entries from a stream', async () => {
+		const zip = createZip({
+			'a.xml': '<a>Hello</a>',
+			'dir/b.xml': '<b>World</b>'
+		})
+		const files = await unzipFromStream(streamFrom(zip))
+		expect(asStrings(files)).to.deep.equal({
+			'a.xml': '<a>Hello</a>',
+			'dir/b.xml': '<b>World</b>'
+		})
+	})
+
+	it('should read "stored" (uncompressed) entries from a stream', async () => {
+		const zip = createZip({ 'a.xml': '<a>Hello</a>' }, { level: 0 })
+		const files = await unzipFromStream(streamFrom(zip))
+		expect(asStrings(files)).to.deep.equal({ 'a.xml': '<a>Hello</a>' })
+	})
+
+	it('should read entries split across small stream chunks', async () => {
+		const zip = createZip({
+			'a.xml': '<a>'.repeat(500),
+			'b.xml': '<b>'.repeat(500)
+		})
+		const files = await unzipFromStream(streamFrom(zip, { chunkSize: 7 }))
+		expect(asStrings(files)).to.deep.equal({
+			'a.xml': '<a>'.repeat(500),
+			'b.xml': '<b>'.repeat(500)
+		})
+	})
+
+	it('should ignore directory entries', async () => {
+		const zip = Buffer.from(zipSync({
+			'dir/': new Uint8Array(0),
+			'dir/a.xml': strToU8('<a/>')
+		}))
+		const files = await unzipFromStream(streamFrom(zip))
+		expect(asStrings(files)).to.deep.equal({ 'dir/a.xml': '<a/>' })
+	})
+
+	it('should ignore entries rejected by the `filter` option', async () => {
+		const zip = createZip({
+			'keep.xml': '<keep/>',
+			'skip.png': 'binary'
+		})
+		const files = await unzipFromStream(streamFrom(zip), {
+			filter: ({ path }) => path.endsWith('.xml')
+		})
+		expect(asStrings(files)).to.deep.equal({ 'keep.xml': '<keep/>' })
+	})
+
+	it('should reject when the source stream errors', async () => {
+		const stream = new Readable({ read() {} })
+		const error = new Error('Stream read failure')
+		process.nextTick(() => stream.emit('error', error))
+
+		let thrown
+		try {
+			await unzipFromStream(stream)
+		} catch (caught) {
+			thrown = caught
+		}
+		expect(thrown).to.equal(error)
+	})
+
+	it('should reject on invalid (non-zip) data', async () => {
+		const garbage = Buffer.from('this is definitely not a zip archive')
+
+		let thrown
+		try {
+			await unzipFromStream(streamFrom(garbage))
+		} catch (caught) {
+			thrown = caught
+		}
+		expect(thrown).to.be.an('error')
+	})
+})


### PR DESCRIPTION
unzipper was the only remaining user of a separate zip library; fflate was already a dependency used by all other code paths. Rewrite unzipFromStream to use fflate's streaming Unzip class, preserving the forward-streaming behavior (entries emitted from local file headers as chunks arrive, no full-archive buffering).

- Register UnzipInflate for deflate; stored entries handled by fflate default
- filter skips entries by not calling start(), so they're never decompressed
- Add a ZIP magic-byte check to keep rejecting non-zip input with a clear error, matching the previous unzipper behavior (fflate is otherwise lenient and yields zero entries for garbage)
- Remove unzipper from dependencies: prunes 15 packages from node_modules (unzipper plus 14 transitive deps, e.g. bluebird, fs-extra, readable-stream), 0 added
- Add unzipFromStream unit tests (deflate, stored, chunk boundaries, filter, stream-error and invalid-data rejection); verified against the previous unzipper implementation too


---

I got a lot of help from Claude here, as some of this is a bit unfamiliar to me. Given the existing comments in the code, I believe this should at least be something in the right direction, and the added tests should give some confidence.